### PR TITLE
Updated with gtag for GA4 property upgrade

### DIFF
--- a/templates/factorial.html
+++ b/templates/factorial.html
@@ -1,14 +1,14 @@
 <!doctype html>
 
 <head>
-    <!-- Global site tag (gtag.js) - Google Analytics -->
-    <script async src="https://www.googletagmanager.com/gtag/js?id=UA-38578610-5"></script>
+    <!-- Google tag (gtag.js) -->
+    <script async src="https://www.googletagmanager.com/gtag/js?id=G-F2PLZ6GCDD"></script>
     <script>
         window.dataLayer = window.dataLayer || [];
-        function gtag() { dataLayer.push(arguments); }
+        function gtag(){dataLayer.push(arguments);}
         gtag('js', new Date());
 
-        gtag('config', 'UA-38578610-5');
+        gtag('config', 'G-F2PLZ6GCDD');
     </script>
     <title>Factoriall</title>
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
- Existing app has gtag accommodating both GA4 and UA properties, as this was the norm for any property created post Oct 2020. 
- Updated html to track the latest GA4 property